### PR TITLE
0.5.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 0.5.2
+
+## Bug fixes
+
+* Workaround an issue with Ansible when SELinux is being used and libselinux
+  python bindings are not present, ansible-playbook freezes for a couple of
+  minutes.
+  * https://bugzilla.redhat.com/show_bug.cgi?id=1696706
+  * https://github.com/ansible-community/ansible-bender/issues/101
+
+## Minor
+
+* Document how to make Ansible roles available during a build if they are on a
+  custom path.
+
+
 # 0.5.1
 
 ## Bug fixes


### PR DESCRIPTION
Hi,
 you have requested a release PR from me. Here it is!
This is the changelog I created:
### Changes
* workaround ansible bug with selinux on and...
* make the test suite pass with setenforce 1
* formatting
* document and test playbooks which use roles
* readme: notify about the move and rephrase
* comment why we generate a pbook in json


You can change it by editing `CHANGELOG.md` in the root of this repository and pushing to `0.5.2-release` branch before merging this PR.
I didn't find any files where  `__version__` is set.