### PR TITLE
0.5.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# 0.5.3
+
+Thank you for contributions from @jamescassell and @alexgarel!
+
+## Bug fixes
+
+* Bender now correctly picks up all cached layers and does not display an error
+  message: `Error: could not get runtime: error creating runtime static files
+  directory /var/lib/containers/storage/libpod: mkdir
+  /var/lib/containers/storage/libpod: permission denied`. This was coming from
+  podman so we switched to buildah to perform checks for presence of layers.
+* A name of a working container now contains month digits instead of minutes as
+  one would expect. (How come that no one noticed?)
+
+## Minor
+
+* README now contains a bit of documentation for limitations of rootless mode.
+
+
 # 0.5.2
 
 ## Bug fixes


### PR DESCRIPTION
Hi,
 you have requested a release PR from me. Here it is!
This is the changelog I created:
### Changes
* document limitations of rootless mode
* podman i exists does not work in buildah unshare
* test_api: better code quality, pep8
* reorder `podman images exists` code a bit
* daata -> data
* fix timestamp in a layer image name
* updated links to github repo in README
* add vagrantfile
* release-bot: don't apply user-cont label


You can change it by editing `CHANGELOG.md` in the root of this repository and pushing to `0.5.3-release` branch before merging this PR.
I didn't find any files where  `__version__` is set.