### PR TITLE
0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.6.0
+
+## Features
+
+* You can specify a user to be used during the build process (`--build-user`). (Thanks to @11mariom #122)
+
+## Bug fixes
+
+* Bender is able to correctly process multiple build volumes. (Thanks to @11mariom #118)
+
+
 # 0.5.3
 
 Thank you for contributions from @jamescassell and @alexgarel!


### PR DESCRIPTION
TODO:
* [x] verify this works with buildah 1.8+

Hi,
 you have requested a release PR from me. Here it is!
This is the changelog I created:
### Changes
* Fix typo in variable name
* Add option to specify build user
* add a test case for a build with 2 build vols
* Fix buildah args when using multiple build volumes


You can change it by editing `CHANGELOG.md` in the root of this repository and pushing to `0.6.0-release` branch before merging this PR.
I didn't find any files where  `__version__` is set.