### PR TITLE
0.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.6.1
+
+## Bug fixes
+
+* Make bender work with ansible 2.8.
+
+## Minor
+
+* Test bender in vagrant VMs against ansible 2.7 and 2.8.
+
+
 # 0.6.0
 
 ## Features


### PR DESCRIPTION
Hi,
 you have requested a release PR from me. Here it is!
This is the changelog I created:
### Changes
* test bender in 2 vagrant VMs: F29 and F30
* ansible 2.8: setup & gather_facts complete fix
* don't bail when we fail to get task content
* ansible 2.8 renamed setup to gather_facts


You can change it by editing `CHANGELOG.md` in the root of this repository and pushing to `0.6.1-release` branch before merging this PR.
I didn't find any files where  `__version__` is set.