### PR TITLE
don't print buildah inspect of base image by default

### DIFF
--- a/ansible_bender/builders/buildah_builder.py
+++ b/ansible_bender/builders/buildah_builder.py
@@ -40,7 +40,7 @@ def does_image_exist(container_image):
     # https://github.com/containers/libpod/issues/2924
     # https://github.com/ansible-community/ansible-bender/issues/114
     cmd = ["buildah", "inspect", "-t", "image", container_image]
-    run_cmd(cmd, print_output=True)
+    run_cmd(cmd, print_output=False)
 
 
 def podman_run_cmd(container_image, cmd, log_stderr=True, return_output=False):


### PR DESCRIPTION
This is pretty annoying since the output is so long. It was being printed by an accident.