### PR TITLE
Allow extra args to `buildah from`

### DIFF
--- a/ansible_bender/cli.py
+++ b/ansible_bender/cli.py
@@ -152,6 +152,10 @@ class CLI:
             nargs="*"
         )
         self.build_parser.add_argument(
+            "--extra-buildah-from-args",
+            help="arguments passed to buildah from command (be careful!)"
+        )
+        self.build_parser.add_argument(
             "--extra-ansible-args",
             help="arguments passed to ansible-playbook command (be careful!)"
         )
@@ -276,6 +280,8 @@ class CLI:
             build.builder_name = self.args.builder
         if self.args.no_cache is not None:
             build.cache_tasks = not self.args.no_cache
+        if self.args.extra_buildah_from_args:
+            build.buildah_from_extra_args = self.args.extra_buildah_from_args
         if self.args.extra_ansible_args:
             build.ansible_extra_args = self.args.extra_ansible_args
         if self.args.python_interpreter:

--- a/ansible_bender/conf.py
+++ b/ansible_bender/conf.py
@@ -136,6 +136,7 @@ class Build:
         self.debug = False
         self.verbose = False
         self.pulled = False  # was the base image pulled?
+        self.buildah_from_extra_args = None
         self.ansible_extra_args = None
         self.python_interpreter = None
         self.verbose_layer_names = False
@@ -167,6 +168,7 @@ class Build:
             "debug": self.debug,
             "verbose": self.verbose,
             "pulled": self.pulled,
+            "buildah_from_extra_args": self.buildah_from_extra_args,
             "ansible_extra_args": self.ansible_extra_args,
             "python_interpreter": self.python_interpreter,
             "verbose_layer_names": self.verbose_layer_names,
@@ -181,6 +183,7 @@ class Build:
         # self.builder_name = None
         self.cache_tasks = graceful_get(data, "cache_tasks", default=self.cache_tasks)
         self.layering = graceful_get(data, "layering", default=self.layering)
+        self.buildah_from_extra_args = graceful_get(data, "buildah_from_extra_args")
         self.ansible_extra_args = graceful_get(data, "ansible_extra_args")
         self.verbose_layer_names = graceful_get(data, "verbose_layer_names")
         # we should probably get this from the official Ansible variable
@@ -218,6 +221,7 @@ class Build:
         b.debug = j["debug"]
         b.verbose = j["verbose"]
         b.pulled = j["pulled"]
+        b.buildah_from_extra_args = j.get("buildah_from_extra_args", None)
         b.ansible_extra_args = j.get("ansible_extra_args", None)
         b.python_interpreter = j.get("python_interpreter", None)
         b.verbose_layer_names = graceful_get(j, "verbose_layer_names", default=False)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,15 +21,16 @@ only from the first play. All the plays will end up in a single container image.
 
 #### Top-level keys
 
-| Key name             | type   | description
-|----------------------|--------|---------------------------------------------------------
-| `base_image`         | string | name of the container image to use as a base
-| `ansible_extra_args` | string | extra CLI arguments to pass to ansible-playbook command
-| `working_container`  | dict   | settings for the container where the build occurs
-| `target_image`       | dict   | metadata of the final image which we built
-| `cache_tasks`        | bool   | When true, enable caching mechanism
-| `layering`           | bool   | When true, snapshot the image after a task is executed
-| `verbose_layer_names`| bool   | tag layers with a verbose name if true (image-name + timestamp), defaults to false
+| Key name                  | type   | description
+|---------------------------|--------|---------------------------------------------------------
+| `base_image`              | string | name of the container image to use as a base
+| `buildah_from_extra_args` | string | extra CLI arguments to pass to buildah from command
+| `ansible_extra_args`      | string | extra CLI arguments to pass to ansible-playbook command
+| `working_container`       | dict   | settings for the container where the build occurs
+| `target_image`            | dict   | metadata of the final image which we built
+| `cache_tasks`             | bool   | When true, enable caching mechanism
+| `layering`                | bool   | When true, snapshot the image after a task is executed
+| `verbose_layer_names`     | bool   | tag layers with a verbose name if true (image-name + timestamp), defaults to false
 
 
 #### `working_container`
@@ -62,6 +63,7 @@ Example of a playbook with variables:
   vars:
     ansible_bender:
       base_image: "docker.io/library/python:3-alpine"
+      buildah_from_extra_args: "--dns 8.8.8.8"
       ansible_extra_args: "-vvv"
 
       working_container:
@@ -89,11 +91,13 @@ Please check out `ansible-bender build --help` for up to date options:
 $ ansible-bender build -h
 usage: ansible-bender build [-h] [--builder {docker,buildah}] [--no-cache]
                             [--build-volumes [BUILD_VOLUMES [BUILD_VOLUMES ...]]]
-                            [-w WORKDIR] [-l [LABELS [LABELS ...]]]
+                            [--build-user BUILD_USER] [-w WORKDIR]
+                            [-l [LABELS [LABELS ...]]]
                             [--annotation [ANNOTATIONS [ANNOTATIONS ...]]]
                             [-e [ENV_VARS [ENV_VARS ...]]] [--cmd CMD]
                             [-u USER] [-p [PORTS [PORTS ...]]]
                             [--runtime-volumes [RUNTIME_VOLUMES [RUNTIME_VOLUMES ...]]]
+                            [--extra-buildah-from-args EXTRA_BUILDAH_FROM_ARGS]
                             [--extra-ansible-args EXTRA_ANSIBLE_ARGS]
                             [--python-interpreter PYTHON_INTERPRETER]
                             PLAYBOOK_PATH [BASE_IMAGE] [TARGET_IMAGE]
@@ -115,7 +119,8 @@ optional arguments:
                         mount selected directory inside the container during
                         build, should be specified as
                         '/host/dir:/container/dir'
-  --build-user USER     the container gets invoked with this user during build
+  --build-user BUILD_USER
+                        the container gets invoked with this user during build
   -w WORKDIR, --workdir WORKDIR
                         path to an implicit working directory in the container
   -l [LABELS [LABELS ...]], --label [LABELS [LABELS ...]]
@@ -133,6 +138,8 @@ optional arguments:
   --runtime-volumes [RUNTIME_VOLUMES [RUNTIME_VOLUMES ...]]
                         path a directory which has data stored outside of the
                         container
+  --extra-buildah-from-args EXTRA_BUILDAH_FROM_ARGS
+                        arguments passed to buildah from command (be careful!)
   --extra-ansible-args EXTRA_ANSIBLE_ARGS
                         arguments passed to ansible-playbook command (be
                         careful!)


### PR DESCRIPTION
This PR adds an `--extra-buildah-args`, similar to `--extra-ansible-args`, to add extra arguments to the `buildah from` command. In my case, I need this because I need to pass `--dns=none` to buildah, so it does not try and put a bind mount on /etc/resolv.conf.

Marked as WIP pending addition of documentation updates; addition of documentation updates pending discussion with project maintainers on if they would actually find this desirable ;)