### PR TITLE
add :Z to simple-playbook.yaml demonstration to support volume mount …

### DIFF
--- a/simple-playbook.yaml
+++ b/simple-playbook.yaml
@@ -7,7 +7,7 @@
 
       working_container:
         volumes:
-          - '{{ playbook_dir }}:/src'
+          - '{{ playbook_dir }}:/src:Z'
 
       target_image:
         name: a-very-nice-image


### PR DESCRIPTION
…under selinux

Running the example fails under selinux because the volume mount specified does not have the Z option that ensures that the host directory is accessible inside the container. The failure is a "permission denied" when trying to access the mount at `/src`.