### PR TITLE
Add support for squashing final image

### DIFF
--- a/ansible_bender/builders/buildah_builder.py
+++ b/ansible_bender/builders/buildah_builder.py
@@ -227,12 +227,16 @@ class BuildahBuilder(Builder):
 
         if image_name:
             args = [self.ansible_host, image_name]
+            if final_image and self.build.squash:
+                args.insert(0, "--squash")
             buildah("commit", args, print_output=print_output, debug=self.debug)
             return self.get_image_id(image_name)
         else:
             fd, name = tempfile.mkstemp()
             os.close(fd)
             args = ["-q", "--iidfile", name, self.ansible_host]
+            if final_image and self.build.squash:
+                args.insert(0, "--squash")
             try:
                 buildah("commit", args, print_output=print_output, debug=self.debug)
                 image_id = Path(name).read_text()

--- a/ansible_bender/cli.py
+++ b/ansible_bender/cli.py
@@ -104,6 +104,12 @@ class CLI:
                  "this option also implies the final image is composed of a base image and one additional layer"
         )
         self.build_parser.add_argument(
+            "--squash",
+            action="store_true",
+            default=False,
+            help="squash final image down to a single layer"
+        )
+        self.build_parser.add_argument(
             "--build-volumes",
             help="mount selected directory inside the container during build, "
                  "should be specified as '/host/dir:/container/dir'",
@@ -284,6 +290,8 @@ class CLI:
             build.builder_name = self.args.builder
         if self.args.no_cache is not None:
             build.cache_tasks = not self.args.no_cache
+        if self.args.squash:
+            build.squash = self.args.squash
         if self.args.extra_buildah_from_args:
             build.buildah_from_extra_args = self.args.extra_buildah_from_args
         if self.args.extra_ansible_args:

--- a/ansible_bender/conf.py
+++ b/ansible_bender/conf.py
@@ -133,6 +133,7 @@ class Build:
         self.cache_tasks = True  # we cache by default, a user can opt out
         self.log_lines = []  # a list of strings
         self.layering = True
+        self.squash = False
         self.debug = False
         self.verbose = False
         self.pulled = False  # was the base image pulled?
@@ -165,6 +166,7 @@ class Build:
             # we could compress/base64 here, let's go for the easier solution first
             "log_lines": self.log_lines,
             "layering": self.layering,
+            "squash": self.squash,
             "debug": self.debug,
             "verbose": self.verbose,
             "pulled": self.pulled,
@@ -183,6 +185,7 @@ class Build:
         # self.builder_name = None
         self.cache_tasks = graceful_get(data, "cache_tasks", default=self.cache_tasks)
         self.layering = graceful_get(data, "layering", default=self.layering)
+        self.squash = graceful_get(data, "squash", default=self.squash)
         self.buildah_from_extra_args = graceful_get(data, "buildah_from_extra_args")
         self.ansible_extra_args = graceful_get(data, "ansible_extra_args")
         self.verbose_layer_names = graceful_get(data, "verbose_layer_names")
@@ -218,6 +221,7 @@ class Build:
         b.cache_tasks = j["cache_tasks"]
         b.log_lines = j["log_lines"]
         b.layering = j["layering"]
+        b.squash = j["squash"]
         b.debug = j["debug"]
         b.verbose = j["verbose"]
         b.pulled = j["pulled"]

--- a/ansible_bender/schema.py
+++ b/ansible_bender/schema.py
@@ -21,6 +21,7 @@ BUILD_SCHEMA = {
         "cache_tasks",
         "log_lines",
         "layering",
+        "squash",
         "debug",
         "verbose",
         "pulled",
@@ -168,6 +169,15 @@ BUILD_SCHEMA = {
             "$id": "#/properties/layering",
             "type": "boolean",
             "title": "Should we layer after each task?",
+            "default": "",
+            "examples": [
+                False
+            ],
+        },
+        "squash": {
+            "$id": "#/properties/squash",
+            "type": "boolean",
+            "title": "Should we squash the final image to a single layer?",
             "default": "",
             "examples": [
                 False

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,7 @@ only from the first play. All the plays will end up in a single container image.
 | `target_image`            | dict   | metadata of the final image which we built
 | `cache_tasks`             | bool   | When true, enable caching mechanism
 | `layering`                | bool   | When true, snapshot the image after a task is executed
+| `squash`                  | bool   | When true, squash the final image down to a single layer
 | `verbose_layer_names`     | bool   | tag layers with a verbose name if true (image-name + timestamp), defaults to false
 
 
@@ -90,6 +91,7 @@ Please check out `ansible-bender build --help` for up to date options:
 ```
 $ ansible-bender build -h
 usage: ansible-bender build [-h] [--builder {docker,buildah}] [--no-cache]
+                            [--squash]
                             [--build-volumes [BUILD_VOLUMES [BUILD_VOLUMES ...]]]
                             [--build-user BUILD_USER] [-w WORKDIR]
                             [-l [LABELS [LABELS ...]]]
@@ -115,6 +117,7 @@ optional arguments:
                         them if a task is unchanged; this option also implies
                         the final image is composed of a base image and one
                         additional layer
+  --squash              squash final image down to a single layer
   --build-volumes [BUILD_VOLUMES [BUILD_VOLUMES ...]]
                         mount selected directory inside the container during
                         build, should be specified as


### PR DESCRIPTION
This adds support for `--squash` as a command-line and a configuration option. If specified, it will pass `--squash` along down to `buildah commit` while committing the final layer. This will squash the resulting image down to one layer.