### PR TITLE
Prevent overwriting the build id in the database

### DIFF
--- a/ansible_bender/db.py
+++ b/ansible_bender/db.py
@@ -161,7 +161,7 @@ class Database:
         if not data["builds"].get[next_build_id]:
             return str(next_build_id)
         else:
-            raise Exception('Build ID already exists')
+            raise Exception(f'Database seems to be corrupted. Build {next_build_id_str} already exists.')
 
 
     def record_build(self, build_i, build_id=None, build_state=None, set_finish_time=False):

--- a/ansible_bender/db.py
+++ b/ansible_bender/db.py
@@ -158,7 +158,7 @@ class Database:
         """ return id for next build id and increment the one in DB """
         next_build_id = data["next_build_id"]
         data["next_build_id"] += 1
-        if data["builds"].get[next_build_id]:
+        if not data["builds"].get[next_build_id]:
             return str(next_build_id)
         else:
             raise Exception('Build ID already exists')

--- a/ansible_bender/db.py
+++ b/ansible_bender/db.py
@@ -158,8 +158,11 @@ class Database:
         """ return id for next build id and increment the one in DB """
         next_build_id = data["next_build_id"]
         data["next_build_id"] += 1
-        # TODO: verify such build is not in DB, we don't want to overwrite, just in case
-        return str(next_build_id)
+        if data["builds"].get[next_build_id]:
+            return str(next_build_id)
+        else:
+            raise Exception('Build ID already exists')
+
 
     def record_build(self, build_i, build_id=None, build_state=None, set_finish_time=False):
         """

--- a/ansible_bender/db.py
+++ b/ansible_bender/db.py
@@ -158,10 +158,10 @@ class Database:
         """ return id for next build id and increment the one in DB """
         next_build_id = data["next_build_id"]
         data["next_build_id"] += 1
-        if not data["builds"].get[next_build_id]:
+        if not data["builds"].get(str(next_build_id)):
             return str(next_build_id)
         else:
-            raise Exception(f'Database seems to be corrupted. Build {next_build_id_str} already exists.')
+            raise Exception(f'Database seems to be corrupted. Build {next_build_id} already exists.')
 
 
     def record_build(self, build_i, build_id=None, build_state=None, set_finish_time=False):


### PR DESCRIPTION
### Context 
A check is added, if the new build-id already exists in the database, then throws an exception rather overwriting it, otherwise works as usual.