### PR TITLE
Add plattform-python path used in rhel8/centos8 to 'search path'

### DIFF
--- a/ansible_bender/builders/base.py
+++ b/ansible_bender/builders/base.py
@@ -34,6 +34,7 @@ class Builder:
             "/usr/local/bin/python2",
             "/usr/bin/python",
             "/usr/local/bin/python",
+            "/usr/libexec/platform-python",
         )
 
     def create(self):


### PR DESCRIPTION
Related to #170 