### PR TITLE
Patch to Makefile and setup configuration for better testing environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,19 @@
+# test artifacts
 tests/data/basic_playbook.retry
 tests/data/basic_playbook_with_volume.retry
 contrib/ab-pod.yml
 .coverage.*
 .coverage*
+
+# python artifacts
+__pycache__/
+*.pyc
+*$py.class
+pip-log.txt
+pip-delete-this-directory.txt
+.python-version
+.mypy_cache/
+.dmypy.json
+dmypy.json
+.pyre/
+

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,13 @@ PY_PACKAGE := ansible-bender
 # container image with ab inside
 CONT_IMG := $(PY_PACKAGE)
 ANSIBLE_BENDER := python3 -m ansible_bender.cli
+PYTEST_EXEC := pytest-3
 
 build-ab-img: recipe.yml
 	$(ANSIBLE_BENDER) build -- ./recipe.yml $(BASE_IMAGE) $(CONT_IMG)
 
 check:
-	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=yes pytest-3 --cov=ansible_bender -l -v $(TEST_TARGET)
+	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=yes $(PYTEST_EXEC) --cov=ansible_bender -l -v $(TEST_TARGET)
 
 check-a-lot:
 	WITH_TESTS=yes vagrant up --provision

--- a/ansible_bender/core.py
+++ b/ansible_bender/core.py
@@ -1,5 +1,5 @@
 """
-Module to interact with Ansible, perform ansible-pleybook and extract metadata from Ansible vars
+Module to interact with Ansible, perform ansible-playbook and extract metadata from Ansible vars
 
 A sample configuration:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ install_requires =
 testing =
     pytest
     flexmock
+    pytest-cov
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
### Changes made
* Updated gitignore file for better development env
* Make fails as `pytest-3` command is not found so made patch to alternative choose `pytest` command instead
* Added `pytest-cov` plugin package to requirements as Makefile check uses it.