### PR TITLE
Enable copr builds and add packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,15 @@
+downstream_package_name: ansible-bender
+jobs:
+- job: copr_build
+  metadata:
+    targets:
+    - fedora-29-x86_64
+    - fedora-30-x86_64
+    - fedora-31-x86_64
+    - fedora-rawhide-x86_64
+  trigger: pull_request
+specfile_path: ansible-bender.spec
+synced_files:
+- ansible-bender.spec
+- .packit.yaml
+upstream_package_name: ansible-bender

--- a/ansible-bender.spec
+++ b/ansible-bender.spec
@@ -1,0 +1,100 @@
+# All tests require Internet access
+# to test in mock use:  --enable-network --with check
+# to test in a privileged environment use:
+#   --with check --with privileged_tests
+%bcond_with     check
+%bcond_with     privileged_tests
+
+Name:           ansible-bender
+Version:        0.7.0
+Release:        4%{?dist}
+Summary:        Build container images using Ansible playbooks
+
+License:        MIT
+URL:            https://github.com/ansible-community/ansible-bender
+Source0:        %{pypi_source}
+
+BuildArch:      noarch
+
+BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-setuptools
+BuildRequires:  python%{python3_pkgversion}-setuptools_scm
+BuildRequires:  python%{python3_pkgversion}-setuptools_scm_git_archive
+%if %{with check}
+# These are required for tests:
+BuildRequires:  python%{python3_pkgversion}-pyyaml
+BuildRequires:  python%{python3_pkgversion}-tabulate
+BuildRequires:  python%{python3_pkgversion}-jsonschema
+BuildRequires:  python%{python3_pkgversion}-pytest
+BuildRequires:  python%{python3_pkgversion}-flexmock
+BuildRequires:  python%{python3_pkgversion}-pytest-xdist
+BuildRequires:  python%{python3_pkgversion}-libselinux
+BuildRequires:  ansible
+BuildRequires:  podman
+BuildRequires:  buildah
+BuildRequires:  git
+%endif
+Requires:       ansible
+Requires:       buildah
+
+%description
+This is a tool which bends containers using Ansible playbooks and
+turns them into container images. It has a pluggable builder selection
+- it is up to you to pick the tool which will be used to construct
+your container image. Right now the only supported builder is
+buildah. More to come in the future. Ansible-bender (ab) relies on
+Ansible connection plugins for performing builds.
+
+tl;dr Ansible is the frontend, buildah is the backend.
+
+%prep
+%autosetup
+
+
+%build
+%py3_build
+
+
+%install
+%py3_install
+
+
+%if %{with check}
+%check
+PYTHONPATH=%{buildroot}%{python3_sitelib} \
+  pytest-3 \
+  -v \
+  --disable-pytest-warnings \
+  --numprocesses=auto \
+%if %{with privileged_tests}
+  tests
+%else
+  tests/unit
+%endif
+%endif
+
+
+%files
+%{python3_sitelib}/ansible_bender-*.egg-info/
+%{python3_sitelib}/ansible_bender/
+%{_bindir}/ansible-bender
+%license LICENSE
+%doc docs/* README.md
+
+
+
+%changelog
+* Thu Oct 03 2019 Miro Hrončok <mhroncok@redhat.com> - 0.7.0-4
+- Rebuilt for Python 3.8.0rc1 (#1748018)
+
+* Mon Aug 19 2019 Miro Hrončok <mhroncok@redhat.com> - 0.7.0-3
+- Rebuilt for Python 3.8
+
+* Wed Jul 24 2019 Fedora Release Engineering <releng@fedoraproject.org> - 0.7.0-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_31_Mass_Rebuild
+
+* Wed Jul 03 2019 Gordon Messmer <gordon.messmer@gmail.com> - 0.7.0-1
+- Build 0.7.0
+
+* Tue Jul 02 2019 Gordon Messmer <gordon.messmer@gmail.com> - 0.6.1-6
+- First build for Fedora


### PR DESCRIPTION
Let us introduce [packit service](https://packit.dev) to you - the automation to integrate upstream open source projects into Fedora operating system.

After merging this PR, you are just a few steps away from RPM builds being automatically triggered on your PR's.
It means, that you'll be able to try and play with your change, packaged as an RPM.

But there is more. By using packit, you can for example enable adding new releases into Fedora Rawhide.

What are the next steps?
* Install [Packit-as-a-Service github application](https://github.com/marketplace/packit-as-a-service) in your repo
* In case you are first user, wait for account approval
* Enjoy the built RPMs!

For more info, please:
 * check out the documentation: https://packit.dev/docs/
 * contact [@packit-service/the-packit-team](https://github.com/orgs/packit-service/teams/the-packit-team)

The spec you see in this PR was fetched from your package's Fedora dist-git.
