### PR TITLE
Extend sanity check by adding buildah run true command

### DIFF
--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -13,18 +13,19 @@ from ansible_bender.builders.buildah_builder import BuildahBuilder
 def test_build_pulls_base_img_if_not_present(application, build, is_base_present, times_called):
     build.base_image = "very-good/and-warm:mead"
 
-    flexmock(BuildahBuilder)
-    BuildahBuilder.should_receive("is_base_image_present").and_return(is_base_present).once()
-    BuildahBuilder.should_receive("pull").times(times_called)
-    BuildahBuilder.should_receive("check_container_creation").and_return(None).once()
-    BuildahBuilder.should_receive("get_image_id").and_return("1").once()
-    BuildahBuilder.should_receive("find_python_interpreter").and_return("").once()
-    BuildahBuilder.should_receive("create").once()
-    BuildahBuilder.should_receive("commit").once()
-    BuildahBuilder.should_receive("clean").once()
+    B = flexmock(BuildahBuilder)
+    B.should_receive("sanity_check").and_return(None)
+    B.should_receive("is_base_image_present").and_return(is_base_present).once()
+    B.should_receive("pull").times(times_called)
+    B.should_receive("check_container_creation").and_return(None).once()
+    B.should_receive("get_image_id").and_return("1").once()
+    B.should_receive("find_python_interpreter").and_return("").once()
+    B.should_receive("create").once()
+    B.should_receive("commit").once()
+    B.should_receive("clean").once()
 
-    flexmock(AnsibleRunner)
-    AnsibleRunner.should_receive('build').and_return("").once()
+    A = flexmock(AnsibleRunner)
+    A.should_receive('build').and_return("").once()
 
     application.build(build)
 


### PR DESCRIPTION
## Context
* Added buildah_run_cmd() definition to run true command in a given container image and for sanity check.
* related to #148 