### PR TITLE
[WIP]Suppress error when hosts key not found in playbook

### DIFF
--- a/ansible_bender/core.py
+++ b/ansible_bender/core.py
@@ -205,10 +205,18 @@ class AnsibleRunner:
             tmp_pb_path = os.path.join(tmp, "p.yaml")
             with open(self.pb, "r") as fd_r:
                 pb_dict = yaml.safe_load(fd_r)
+                host_present = False
             for idx, doc in enumerate(pb_dict):
-                host = doc["hosts"]
-                logger.debug("play[%s], host = %s", idx, host)
-                doc["hosts"] = self.builder.ansible_host
+                try:
+                    host = doc["hosts"]
+                    host_present = True
+                except:
+                    continue
+                finally:
+                    if host_present:
+                    logger.debug("play[%s], host = %s", idx, host)
+                    doc["hosts"] = self.builder.ansible_host
+                    break
             with open(tmp_pb_path, "w") as fd:
                 yaml.safe_dump(pb_dict, fd)
             playbook_base = os.path.basename(self.pb).split(".", 1)[0]


### PR DESCRIPTION
## Context 
* partially fixes #109 
* As ansible-bender tries to modify the host key in the playbook, perhaps fails when it is not found or hidden in any of the playbooks imported. 


