### PR TITLE
drop the python packaging check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,20 +45,6 @@ check-in-okd:
 	sleep 2
 	oc logs -f pod/ab
 
-check-pypi-packaging:
-	podman run --rm -ti -v $(CURDIR):/src:Z -w /src $(CONT_IMG) bash -c '\
-		set -x \
-		&& rm -f dist/* \
-		&& python3 ./setup.py sdist bdist_wheel \
-		&& pip3 install dist/*.tar.gz \
-		&& ansible-bender --help \
-		&& ansible-bender build --help \
-		&& pip3 show $(PY_PACKAGE) \
-		&& twine check ./dist/* \
-		&& python3 -c "import ansible_bender; ansible_bender.__version__.startswith(\"0.3.1\")" \
-		&& pip3 show -f $(PY_PACKAGE) | ( grep test && exit 1 || :) \
-		'
-
 #FIXME: try outer container to be rootless
 #       build tests image
 #       run tests as an unpriv user

--- a/recipe.yml
+++ b/recipe.yml
@@ -45,12 +45,6 @@
       name: docker
       state: started
     when: with_tests == "yes"
-  - name: Install latest twine for sake of check command
-    pip:
-      name:
-      - twine  # we need newest twine, b/c of the check command
-      - readme_renderer[md]
-      state: latest
   # - name: Change storage driver to vfs (ovl on ovl doesn't work)
   #   lineinfile:
   #     path: /etc/containers/storage.conf


### PR DESCRIPTION
it wasn't used anywhere and we have better ways of doing this now

The main aim of this PR is to make all the checks green.