### PR TITLE
0.8.0 release

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -18,9 +18,10 @@ jobs:
   trigger: pull_request
   metadata:
     targets:
-    # tests pass here
     - fedora-30-x86_64
-    # https://github.com/ansible-community/ansible-bender/issues/181
     - fedora-31-x86_64
-    # we can't even the provision test env here: twine fails to install
     - fedora-rawhide-x86_64
+- job: propose_downstream
+  trigger: release
+  metadata:
+    dist-git-branch: master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,66 @@
+# 0.8.0
+
+Thank you to all the contributors! You are awesome!
+
+And special thanks to @kmehant, our [Red Hat Open Source Contest 2019](https://research.redhat.com/red-hat-open-source-contest/) student.
+
+## Features
+
+* You can now pass extra arguments to `buildah from` call when bender creates
+  new build container. This can be done from CLI using
+  `--extra-buildah-from-args` option of build command or in the playbook:
+  `vars → ansible-bender → buildah_from_extra_args`. Thanks to @jordemort #140
+* One can print bender's version using `-V/--version` options.
+* The final image build by bender can now be squashed — all layers merged into
+  one. This can be done with the `--squash` option or in the playbook: `vars →
+  ansible-bender → squash`. @jordemort #154
+* Entrypoints now can be set! Aside from default container commands. Similar
+  drill: `--entrypoint` or `vars → ansible-bender → target_image → entrypoint`,
+  thanks you, @slopedog #155
+* Build times in `list-builds` are now more readable, enjoy! Thanks to @kmehant
+  #161
+* Bender can now locate platform-python of RHEL 8 and CentOS 8, thanks to
+  @hhenkel #171
+* When running bender in debug mode (--debug), ansible stdout callback plugin
+  is set to debug (`ANSIBLE_STDOUT_CALLBACK=debug`). @kmehant #175
+* Ansible executes a playbook in the buildah container using `buildah run`
+  command. Before bender gets to that point, it tries to create a no-op
+  container (`buildah from --name $container $base_image && buildah run
+  $container true`) first to verify that the container runtime is correctly set
+  up. @kmehant #174
+* We have two new subcommands:
+  * `init` — create a template playbook in the current working directory so you
+    can get on-board bender's train more easily. @kmehant #184
+  * `clean` — clean images from database which are no longer present on disk
+    @kmehant #180
+
+## Bug fixes
+
+* Buildah 1.7.3 introduced a backwards-incompatible change to `commit` command
+  which required changes in bender's code. Bender is now able to work with
+  both: buildah `< 1.7.3` and `>= 1.7.3`. CentOS 8.0 and RHEL 8.0 have buildah
+  `< 1.7.3`.
+* Bender is using file locking when using its database (`~/.cache/ab/db.json`),
+  the locks are now atomic thanks to @kmehant #176
+* When you set bender-specific variables in your playbook (`vars →
+  ansible-bender`) and there is a typo in any of the variables or the variable
+  is not recognized, bender exits and informs you about this problem — we have
+  implemented this to prevent typos in the configuration so that you would not
+  be able to build invalid images. @kmehant #189
+* Bender no longer prints output from buildah pull as errors. @kmehant #195
+
+## Minor
+
+* [Contribution guide](/CONTRIBUTING.md) is now placed in the upstream repo.
+* You can now invoke ansible-bender directly from the upstream git repo using
+  the common python way:
+  ```
+  $ python3 -m ansible_bender --help
+  ```
+  @kmehant #160
+* Bender is now using [Packit project](https://packit.dev/) for continuous integration.
+
+
 # 0.7.0
 
 ## Changes

--- a/ansible-bender.spec
+++ b/ansible-bender.spec
@@ -6,8 +6,8 @@
 %bcond_with     privileged_tests
 
 Name:           ansible-bender
-Version:        0.7.0
-Release:        4%{?dist}
+Version:        0.8.0
+Release:        1%{?dist}
 Summary:        Build container images using Ansible playbooks
 
 License:        MIT
@@ -84,6 +84,9 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} \
 
 
 %changelog
+* Tue Nov 19 2019 Tomas Tomecek <ttomecek@redhat.com> - 0.8.0-1
+- new upstream release: 0.8.0
+
 * Thu Oct 03 2019 Miro Hrončok <mhroncok@redhat.com> - 0.7.0-4
 - Rebuilt for Python 3.8.0rc1 (#1748018)
 


### PR DESCRIPTION
Hi,
 you have requested a release PR from me. Here it is!
This is the changelog I created:
### Changes
* Fix messages in init subcommand
* Update ab init message
* Add functional tests to init subcommand
* Add init subcommand to ab
* Add init subcommand to docs
* Add functional test for clean sub command
* Add clean subcommand to ab docs
* Add clean subcommand to ab
* Add delete build entry function to ab
* drop the python packaging check
* Utilize test farm system from packit
* place FMF file to the correct place
* remove yaml directive: ---
* utilize packit's testing infra
* tinker packit.yaml, fix the builds
* drop azure pipelines
* buildah_run_cmd: don't rm the cont if it wasn't created
* adapt tests to the new sanity-check
* Extend sanity check by adding buildah run command
* Make ansible output better using ANSIBLE_STDOUT_CALLBACK
* Make lock mechanism atomic
* Fix very small typo
* Add python-cov plugin
* Add pytest fix patch and update gitignore
* buildah get version: add rhel 8 test case
* It is better to not rely on the assumption that all version numbers contain three digits as buildah reports 1.5 on centos 8
* buildah commit: set image name if buildah.version < 1.7.3
* Enable copr builds and add packit config
* Add plattform-python path used in rhel8/centos8 to 'search path'
* Add unit test for fancy_time
* Make build time human readable
* do not require newly added DB opts: forward compat DB
* Made fixes
* Update database corupted exception message
* simple fix
* Add exception to _get_and_bump_build_id()
* Add a helpful docstring to the module.
* Use absolute paths while importing packages.
* Add __main__.py to ab
* Update installation links for dependencies
* check-in-cont: --tmpfs no longer knows exec
* add contribution guide
* Add squash to schema
* added support for buildah --entrypoint
* Add support for squashing final image
* add :Z to simple-playbook.yaml demonstration to support volume mount under selinux
* Delete a leftover version file
* document minimal req on python 3
* add -V/--version to bender
* readme,docs: document passing ANSIBLE_* env vars
* Allow extra args to `buildah from`


You can change it by editing `CHANGELOG.md` in the root of this repository and pushing to `0.8.0-release` branch before merging this PR.
I didn't find any files where  `__version__` is set.