### PR TITLE
Add missing imports and Update list-builds example

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,8 +330,8 @@ We can list builds we have done:
 $ ansible-bender list-builds
   BUILD ID  IMAGE NAME         STATUS    DATE                        BUILD TIME
 ----------  -----------------  --------  --------------------------  --------------
-         1  a-very-nice-image  done      2019-03-02 16:07:47.471912  0:00:12.347721
-         2  a-very-nice-image  done      2019-03-02 16:07:58.858699  0:00:06.242378
+         1  a-very-nice-image  done      2019-03-02 16:07:47.471912  13 minutes
+         2  a-very-nice-image  done      2019-03-02 16:07:58.858699  7 minutes
 ```
 
 

--- a/ansible_bender/cli.py
+++ b/ansible_bender/cli.py
@@ -5,7 +5,7 @@ CLI for ansible builder
 import argparse
 import json
 import sys
-
+import subprocess
 import pkg_resources
 import yaml
 from tabulate import tabulate


### PR DESCRIPTION
* Sorry I forgot to update the docs with my previous PR [fancy time](#161) 
* I am adding the missing import `subprocess` which was breaking clean subcommand when there is nothing to clean (when it is falling to except block)
