### PR TITLE
Report better on returning empty log lines 

### DIFF
--- a/ansible_bender/builder.py
+++ b/ansible_bender/builder.py
@@ -18,4 +18,4 @@ def get_builder(builder_name):
     try:
         return BUILDERS[builder_name]
     except KeyError:
-        raise RuntimeError("No such builder %s", builder_name)
+        raise RuntimeError("No such builder %s" % builder_name)

--- a/ansible_bender/cli.py
+++ b/ansible_bender/cli.py
@@ -350,7 +350,7 @@ class CLI:
         if log_lines:
             print("\n".join(log_lines))
         else:
-            print("Sorry, the latest build has not got any log lines")
+            print(f"There are no logs for build {build_id}")
 
     def _inspect(self):
         build_id = self.args.BUILD_ID

--- a/ansible_bender/cli.py
+++ b/ansible_bender/cli.py
@@ -347,7 +347,10 @@ class CLI:
     def _get_logs(self):
         build_id = self.args.BUILD_ID
         log_lines = self.app.get_logs(build_id=build_id)
-        print("\n".join(log_lines))
+        if log_lines:
+            print("\n".join(log_lines))
+        else:
+            print("Sorry, the latest build has not got any log lines")
 
     def _inspect(self):
         build_id = self.args.BUILD_ID


### PR DESCRIPTION
According to the previous design, get-logs returns the latest build logs if the build-id is none. Perhaps when the latest build does not have any log lines (In progress, New states and few failures too), nothing is printed. 