### PR TITLE
add missing import for clean command

### DIFF
--- a/ansible_bender/cli.py
+++ b/ansible_bender/cli.py
@@ -16,7 +16,8 @@ from ansible_bender.core import PbVarsParser
 from ansible_bender.db import PATH_CANDIDATES
 from ansible_bender.okd import build_inside_openshift
 
-from ansible_bender.utils import fancy_time
+from ansible_bender.utils import fancy_time, run_cmd
+
 
 def split_once_or_fail_with(strink, pattern, error_message):
     """

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -1,7 +1,7 @@
 from .test_buildah import ab
 from ..spellbook import basic_playbook_path, base_image
 from ansible_bender.constants import PLAYBOOK_TEMPLATE
-
+from ansible_bender.utils import run_cmd
 
 def test_inspect_cmd(tmpdir, target_image):
     workdir_path = "/etc"
@@ -73,7 +73,10 @@ def test_get_logs(target_image, tmpdir):
     assert "TASK [print local env vars]" in out
 
 
-def test_clean(tmpdir):
+def test_clean(target_image, tmpdir):
+    cmd = ["build", basic_playbook_path, base_image, target_image]
+    ab(cmd, str(tmpdir))
+    run_cmd(["podman", "rmi", target_image], print_output=True)
     cmd = ["clean"]
     ab(cmd, str(tmpdir))
     out = ab(["clean"], str(tmpdir), return_output=True)


### PR DESCRIPTION
When I run `ansible-bender clean`
Then I got the following error:
```
$ ansible-bender clean                                                                          
Cleaning images from database which are no longer present on the disk...                                                                                                                                    
There was an error during execution: name 'run_cmd' is not defined 
```
This PR only add the missing import to run `clean` command