### PR TITLE
0.8.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 0.8.1
+
+## Fixes
+
+* `clean` command now works properly.
+* If bender can't create a container, a useful error message is now being
+  printed.
+
+## Features
+
+* Warn when you request a change to UID while running in rootless mode (user
+  namespaces are tricky).
+* If an image build failed, bender tagged the image with a `-failed` suffix so
+  it could be inspected further. Now bender also prepends timestamp so one
+  image is not being overwritten over and over.
+
+## Minor
+
+* Improvements to documentation in README and `--help` output.
+
+
 # 0.8.0
 
 Thank you to all the contributors! You are awesome!

--- a/ansible-bender.spec
+++ b/ansible-bender.spec
@@ -6,7 +6,7 @@
 %bcond_with     privileged_tests
 
 Name:           ansible-bender
-Version:        0.8.0
+Version:        0.8.1
 Release:        1%{?dist}
 Summary:        Build container images using Ansible playbooks
 
@@ -84,6 +84,9 @@ PYTHONPATH=%{buildroot}%{python3_sitelib} \
 
 
 %changelog
+* Thu Dec 12 2019 Tomas Tomecek <ttomecek@redhat.com> - 0.8.1-1
+- new upstream release: 0.8.1
+
 * Tue Nov 19 2019 Tomas Tomecek <ttomecek@redhat.com> - 0.8.0-1
 - new upstream release: 0.8.0
 


### PR DESCRIPTION
Hi,
 you have requested a release PR from me. Here it is!
This is the changelog I created:
### Changes
* Add a link in README to bender known variables.
* Warn when user change in rootless mode
* Modify get_latest_build to adjust to present design
* Add help to ab subcommands
* testing: new RFE to skip tests if container runtime is borked
* drop rawhide: buildah is not working in there right now
* Modify test cases
* Add appropriate error message
* report user for empty log lines
* add missing import for clean command
* readme: drop azure pipelines badge
* Update README.md
* Modify tests
* Update failed image naming
* Add timestamp to failed builds to prevent overwrite
* Modify docs and tests
* polish and test playbook vars validation
* better exceptions structure and naming
* drop unused content from json schema
* sanity-check: print output so we can diagnose what's wrong
* Better errors for playbook validation
* Fix  for clean subcommand
* Update list-builds example


You can change it by editing `CHANGELOG.md` in the root of this repository and pushing to `0.8.1-release` branch before merging this PR.
I didn't find any files where  `__version__` is set.