### PR TITLE
vagrant: test on f31

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ CONT_IMG := $(PY_PACKAGE)
 ANSIBLE_BENDER := python3 -m ansible_bender.cli
 PYTEST_EXEC := pytest-3
 
-build-ab-img: recipe.yml
-	$(ANSIBLE_BENDER) build -- ./recipe.yml $(BASE_IMAGE) $(CONT_IMG)
+build-ab-img: contrib/pre-setup.yml
+	$(ANSIBLE_BENDER) build -- ./contrib/pre-setup.yml $(BASE_IMAGE) $(CONT_IMG)
 
 check:
 	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=yes $(PYTEST_EXEC) --cov=ansible_bender -l -v $(TEST_TARGET)
@@ -65,7 +65,8 @@ check-in-docker:
 		bash -c " \
 			set -x \
 			&& dnf install -y ansible make \
-			&& ansible-playbook -i 'localhost,' -e ansible_python_interpreter=/usr/bin/python3 -e test_mode=yes -c local ./recipe.yml \
+			&& ansible-playbook -i 'localhost,' -e ansible_python_interpreter=/usr/bin/python3 -e test_mode=yes -c local ./contrib/pre-setup.yml \
+			&& ansible-playbook -i 'localhost,' -e ansible_python_interpreter=/usr/bin/python3 -e test_mode=yes -c local ./contrib/post-setup.yml \
 			&& id \
 			&& pwd \
 			&& podman info \

--- a/ci.yaml
+++ b/ci.yaml
@@ -4,4 +4,10 @@
     project_dir: "."
     with_bender_install: no
     with_tests: no
-  import_playbook: recipe.yml
+  import_playbook: contrib/pre-setup.yml
+- name: Provision environment with dependncies to run Bender's test suite
+  vars:
+    project_dir: "."
+    with_bender_install: no
+    with_tests: no
+  import_playbook: contrib/post-setup.yml

--- a/contrib/post-setup.yml
+++ b/contrib/post-setup.yml
@@ -1,0 +1,45 @@
+---
+- name: Set up environment for ansible-bender (after reboot)
+  hosts: all
+  vars:
+    test_mode: no  # yes - test in CI, no - build an image
+    project_dir: /src
+    with_tests: no  # yes - run test suite
+    with_bender_install: yes
+    docker_package_name: docker
+    ansible_bender:
+      target_image:
+        workging_dir: /src
+        cmd: /entry.sh
+      working_container:
+        volumes:
+        - "{{ playbook_dir }}:/src"
+  tasks:
+  - name: Start dockerd
+    systemd:
+      name: docker
+      state: started
+    when: with_tests == "yes"
+  - name: stat /src
+    stat:
+      path: /src
+    register: src_path
+    when: test_mode == "no"
+  - name: Let's make sure /src is present
+    assert:
+      that:
+      - 'src_path.stat.isdir'
+    when: test_mode == "no"
+  - name: copy entrypoint script
+    copy:
+      src: contrib/entry.sh
+      dest: /entry.sh
+    when: test_mode == "no"
+  # this requires sources mounted inside at /src
+  - name: Install ansible-bender from the current working directory
+    pip:
+      name: '{{ project_dir }}'
+    tags:
+    - no-cache
+    when: with_bender_install == "yes"
+

--- a/contrib/pre-setup.yml
+++ b/contrib/pre-setup.yml
@@ -1,11 +1,12 @@
 ---
-- name: Containerized ansible-bender
+- name: Set up environment for ansible-bender (before reboot)
   hosts: all
   vars:
     test_mode: no  # yes - test in CI, no - build an image
     project_dir: /src
     with_tests: no  # yes - run test suite
     with_bender_install: yes
+    docker_package_name: docker
     ansible_bender:
       target_image:
         workging_dir: /src
@@ -19,6 +20,22 @@
       name: "*"
       state: latest
     when: with_tests == "yes"
+  - name: "figure out docker package name: F31+ has moby, not docker"
+    set_fact:
+      docker_package_name: moby-engine
+    when: ansible_distribution_major_version >= '31'
+  - name: use cgroups v1
+    lineinfile:
+      state: present
+      path: /etc/default/grub
+      regexp: "^(GRUB_CMDLINE_LINUX=\")^(?!systemd.unified)(.+)"
+      # double escape is yaml's fault
+      line: "\\1systemd.unified_cgroup_hierarchy=0 \\2"
+      backrefs: yes
+    become: true
+  - name: regen grub config
+    command: grub2-mkconfig -o /boot/grub2/grub.cfg
+    become: true
   - name: Install all packages needed to hack on ab.
     dnf:
       name:
@@ -38,13 +55,9 @@
       - python3-flexmock
       - python3-ipdb
       - python3-jsonschema
-      - docker  # one test uses it
+      - python3-tabulate
+      - '{{ docker_package_name }}'  # one test uses it
       state: present
-  - name: Start dockerd
-    systemd:
-      name: docker
-      state: started
-    when: with_tests == "yes"
   # - name: Change storage driver to vfs (ovl on ovl doesn't work)
   #   lineinfile:
   #     path: /etc/containers/storage.conf
@@ -56,21 +69,6 @@
       regexp: '^graphroot = '
       line: 'graphroot = "/tmp/containers"'
     when: with_tests == "no"
-  - name: stat /src
-    stat:
-      path: /src
-    register: src_path
-    when: test_mode == "no"
-  - name: Let's make sure /src is present
-    assert:
-      that:
-      - 'src_path.stat.isdir'
-    when: test_mode == "no"
-  - name: copy entrypoint script
-    copy:
-      src: contrib/entry.sh
-      dest: /entry.sh
-    when: test_mode == "no"
   - name: copy libpod.conf
     copy:
       src: /usr/share/containers/libpod.conf
@@ -83,10 +81,4 @@
       regexp: '^cgroup_manager = '
       line: 'cgroup_manager = "cgroupfs"'
     when: with_tests == "no"
-  # this requires sources mounted inside at /src
-  - name: Install ansible-bender from the current working directory
-    pip:
-      name: '{{ project_dir }}'
-    tags:
-    - no-cache
-    when: with_bender_install == "yes"
+

--- a/tests/functional/test_conf.py
+++ b/tests/functional/test_conf.py
@@ -46,7 +46,8 @@ def test_basic(tmpdir):
         cmd = ["podman", "inspect", "--type", "image", "challet"]
         inspect_data = json.loads(subprocess.check_output(cmd))[0]
 
-        assert inspect_data["Config"]["Labels"] == {"x": "y"}
+        # buildah 1.12 adds this: `{'io.buildah.version': '1.12.0'}`
+        assert inspect_data["Config"]["Labels"]["x"] == "y"
         assert f"asd={data_dir}" in inspect_data["Config"]["Env"]
         assert inspect_data["Config"]["WorkingDir"] == "/src"
     finally:


### PR DESCRIPTION
Fixes #181

Just making sure that bender works on f31. Since F31 has cgroup v2, the vagrant
VM needs to be rebooted and switched back to v1 so we can run all the tests. I
fear this won't be possible to do in CI.