### PR TITLE
Install submodules.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ keywords =
 
 [options]
 python_requires = >=3.6
-packages = ansible_bender
+packages = find:
 include_package_data = True
 
 setup_requires =


### PR DESCRIPTION
I see the the builders and callback plugins are included in the wheel, but they aren't installed by "python3 setup.py install".  I think they need to be added to the packages list in setup.cfg, but I'm curious how the wheel was built, so that they were included.