### PR TITLE
Fix SyntaxWarning from use of is with string literal.

### DIFF
--- a/ansible_bender/core.py
+++ b/ansible_bender/core.py
@@ -367,7 +367,7 @@ class PbVarsParser:
             # validation to error out unknown keys in /vars/ansible_bender
             jsonschema.validate(bender_data, PLAYBOOK_SCHEMA)
         except jsonschema.ValidationError as validation_error:
-            if validation_error.validator is "type":
+            if validation_error.validator == "type":
                 # error is due to invalid value datatype
                 path = "/" + "/".join(validation_error.path)
                 expected_types = validation_error.validator_value


### PR DESCRIPTION
Use of "is" results in this warning:

/usr/lib/python3.8/site-packages/ansible_bender/core.py:370: SyntaxWarning: "is" with a literal. Did you mean "=="?
