### PR TITLE
Exclude tests from installation packages.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,11 @@ install_requires =
     tabulate
     jsonschema
 
+[options.packages.find]
+exclude =
+    tests
+    tests.*
+
 [options.extras_require]
 testing =
     pytest


### PR DESCRIPTION
I have to apologize, because while I verified that find: included all of the packages that should be installed, I did not verify that it didn't include anything else.  The previous change results in tests being installed, which is probably not what we want.  When using find, we have to exclude the tests.  Just as the "packages" setting required both the ansible_bender package and sub-packages individually, the exclusion setting needs to exclude tests and sub-packages of tests.