### PR TITLE
packit: Use alias for Fedora targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -10,16 +10,14 @@ jobs:
 - job: copr_build
   metadata:
     targets:
-    - fedora-30-x86_64
-    - fedora-31-x86_64
+    - fedora-stable
     # - fedora-rawhide-x86_64
   trigger: pull_request
 - job: tests
   trigger: pull_request
   metadata:
     targets:
-    - fedora-30-x86_64
-    - fedora-31-x86_64
+    - fedora-stable
     # - fedora-rawhide-x86_64
 - job: propose_downstream
   trigger: release


### PR DESCRIPTION
Use the 'fedora-stable' alias instead of specifying targets by Fedora
version. This solves Packit errors due to Fedora 30 reaching EOL.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>