### PR TITLE
Adding a mode to the generated copy command.

### DIFF
--- a/ansible_bender/core.py
+++ b/ansible_bender/core.py
@@ -320,7 +320,8 @@ class PbVarsParser:
                 {
                     "copy": {
                         "dest": json_data_path,
-                        "content": jinja_pb_vars_key
+                        "content": jinja_pb_vars_key,
+                        "mode": "preserve"
                     }
                 }
             ]


### PR DESCRIPTION
The generated playbook that is run contains a copy command. With newer
versions of ansible, if the file permissions change between the source
and destination a non-fatal error is raised, E.G.
"utils.py ERROR  [WARNING]: File '/tmp/ab9mbglh13/j.json' created with default
permissions '600'. The previous default was '666'. Specify 'mode' to avoid this warning."

Adding a 'mode: preserve' to the copy call removes this error.