### PR TITLE
use qualified instead of short-name for image

### DIFF
--- a/simple-playbook.yaml
+++ b/simple-playbook.yaml
@@ -3,7 +3,7 @@
   hosts: all
   vars:
     ansible_bender:
-      base_image: python:3-alpine
+      base_image: docker.io/python:3-alpine
 
       working_container:
         volumes:


### PR DESCRIPTION
```
$ ansible-bender build ./simple-playbook.yaml 
11:59:17.795 utils.py          ERROR  short-name "python:3-alpine" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"
11:59:17.796 utils.py          ERROR  level=error msg="exit status 125"
11:59:17.797 buildah_builder.py ERROR  Unable to create or run a container using python:3-alpine with buildah
short-name "python:3-alpine" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"
level=error msg="exit status 125"
There was an error during execution: Command '['buildah', 'from', '--name', 'a-very-nice-image-20211228-115917655205-cont-20211228115917744737', 'python:3-alpine']' returned non-zero exit status 125.
```
This is on Debian stable (bullseye). Debian's podman [doesn't enable short-names by default](https://bugs.debian.org/978650) so on Debian systems the example will fail.