### PR TITLE
Cache Python interpreter location for each base image

### DIFF
--- a/ansible_bender/api.py
+++ b/ansible_bender/api.py
@@ -86,8 +86,10 @@ class Application:
             build.build_start_time = datetime.datetime.now()
             self.db.record_build(build, build_state=BuildState.IN_PROGRESS)
 
+            build.python_interpreter = build.python_interpreter or self.db.load_python_interpreter(base_image_id)
             if not build.python_interpreter:
                 build.python_interpreter = builder.find_python_interpreter()
+                self.db.record_python_interpreter(base_image_id, build.python_interpreter)
 
             builder.create()
         except Exception:

--- a/ansible_bender/db.py
+++ b/ansible_bender/db.py
@@ -264,3 +264,30 @@ class Database:
                 raise RuntimeError("There is no such build with ID %s" % build_id)
             finally:
                 self._save(data)
+
+    def load_python_interpreter(self, base_image_id):
+        """
+        loads the python interpreter path from the base image. Works for the top-level base image only, layer image ids will not be found.
+
+        :param base_image_id: str, id/hash of the base image
+        :return: python interpreter path if found, None otherwise
+        """
+        with self.acquire():
+            data = self._load()
+            store = data["store"]
+            store.setdefault(base_image_id, {})
+            return store[base_image_id].get("python_interpreter")
+
+    def record_python_interpreter(self, base_image_id, python_interpreter):
+        """
+        records/caches the python interpreter path for later use.
+
+        :param base_image_id: str, id/hash of the base image
+        :param python_interpreter: str, path of the python interpreter on the base image
+        """
+        with self.acquire():
+            data = self._load()
+            store = data["store"]
+            store.setdefault(base_image_id, {})
+            store[base_image_id]["python_interpreter"] = python_interpreter
+            self._save(data)


### PR DESCRIPTION
Uses the ansible-bender database to store the Python interpreter location for each base image. This saves some time when building for base images where the interpreter is in a non-standard location like /usr/libexec/platform-python. 


Implements #257 
Does not implement the additional suggestion in the comments, only the caching part.