### PR TITLE
Initial import_playbook support

### DIFF
--- a/ansible_bender/core.py
+++ b/ansible_bender/core.py
@@ -40,6 +40,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+import uuid
 
 import jsonschema
 import yaml
@@ -173,6 +174,29 @@ class AnsibleRunner:
         # hence, let's add the site ab is installed in to sys.path
         return os.path.dirname(os.path.dirname(ansible_bender.__file__))
 
+    def _correct_host_entries(self, playbook_path, tmpDir):
+        """ Correct the host entries in the playbook and all imported playbooks """
+        tmp_pb_path = os.path.join(tmpDir, str(uuid.uuid4()) + ".yaml")
+
+        with open(playbook_path, "r") as fd_r:
+            pb_dict = yaml.safe_load(fd_r)
+            
+        for idx, doc in enumerate(pb_dict):
+            imported_playbook = doc.get("import_playbook")
+            if imported_playbook:
+                import_base_path = os.path.dirname(playbook_path)
+                imported_playbook_path = os.path.join(import_base_path, imported_playbook)
+                doc["import_playbook"] = self._correct_host_entries(imported_playbook_path, tmpDir)
+            else:
+                host = doc["hosts"]
+                logger.debug("play[%s], host = %s", idx, host)
+                doc["hosts"] = self.builder.ansible_host
+
+        with open(tmp_pb_path, "w") as fd:
+            yaml.safe_dump(pb_dict, fd)
+
+        return tmp_pb_path
+    
     def build(self, db_path):
         """
         run the playbook against the container
@@ -204,15 +228,7 @@ class AnsibleRunner:
             with open(a_cfg_path, "w") as fd:
                 self._create_ansible_cfg(fd)
 
-            tmp_pb_path = os.path.join(tmp, "p.yaml")
-            with open(self.pb, "r") as fd_r:
-                pb_dict = yaml.safe_load(fd_r)
-            for idx, doc in enumerate(pb_dict):
-                host = doc["hosts"]
-                logger.debug("play[%s], host = %s", idx, host)
-                doc["hosts"] = self.builder.ansible_host
-            with open(tmp_pb_path, "w") as fd:
-                yaml.safe_dump(pb_dict, fd)
+            tmp_pb_path = self._correct_host_entries(self.pb, tmp)
             playbook_base = os.path.basename(self.pb).split(".", 1)[0]
             timestamp = datetime.datetime.now().strftime(TIMESTAMP_FORMAT)
             symlink_name = f".{playbook_base}-{timestamp}-{random_str()}.yaml"

--- a/ansible_bender/core.py
+++ b/ansible_bender/core.py
@@ -176,7 +176,7 @@ class AnsibleRunner:
 
     def _correct_host_entries(self, playbook_path, tmpDir):
         """ Correct the host entries in the playbook and all imported playbooks """
-        tmp_pb_path = os.path.join(tmpDir, str(uuid.uuid4()) + ".yaml")
+        tmp_pb_path = os.path.join(tmpDir, "ab_" + str(uuid.uuid4()) + ".yaml")
 
         with open(playbook_path, "r") as fd_r:
             pb_dict = yaml.safe_load(fd_r)
@@ -186,6 +186,7 @@ class AnsibleRunner:
             if imported_playbook:
                 import_base_path = os.path.dirname(playbook_path)
                 imported_playbook_path = os.path.join(import_base_path, imported_playbook)
+                logger.debug("Encountered import_playbook, correcting hosts entries in imported file: %s", imported_playbook_path)
                 doc["import_playbook"] = self._correct_host_entries(imported_playbook_path, tmpDir)
             else:
                 host = doc["hosts"]

--- a/tests/data/import_playbook_basic.yaml
+++ b/tests/data/import_playbook_basic.yaml
@@ -1,0 +1,6 @@
+- import_playbook: imported_playbook.yaml
+  vars:
+    ansible_bender:
+      base_image: python:3.5-stretch
+      target_image:
+        name: test_img

--- a/tests/data/import_playbook_recursive.yaml
+++ b/tests/data/import_playbook_recursive.yaml
@@ -1,0 +1,13 @@
+# doing a few different tasks including importing a playbook
+- import_playbook: imported_playbook_upper.yaml
+  vars:
+    ansible_bender:
+      base_image: python:3.5-stretch
+      target_image:
+        name: test_img
+- hosts: all
+  tasks:
+    - name: create a file
+      copy:
+        src: '{{ playbook_dir }}/a_bag_of_fun'
+        dest: /fun

--- a/tests/data/imported_playbook.yaml
+++ b/tests/data/imported_playbook.yaml
@@ -1,0 +1,4 @@
+- hosts: all
+  tasks:
+    - debug:
+        msg: hi

--- a/tests/data/imported_playbook_upper.yaml
+++ b/tests/data/imported_playbook_upper.yaml
@@ -1,0 +1,9 @@
+- hosts: all
+  tasks:
+    - debug:
+        msg: hello there
+- import_playbook: imported_playbook.yaml
+- hosts: all
+  tasks:
+    - debug:
+        msg: more hello

--- a/tests/spellbook.py
+++ b/tests/spellbook.py
@@ -23,6 +23,8 @@ bad_playbook_path = os.path.join(data_dir, "bad_playbook.yaml")
 role_pb_path = os.path.join(data_dir, "role.yaml")
 playbook_with_unknown_keys = os.path.join(data_dir, "playbook_with_unknown_keys.yaml")
 playbook_wrong_type = os.path.join(data_dir, "pb_wrong_type.yaml")
+import_playbook_basic = os.path.join(data_dir, "import_playbook_basic.yaml")
+import_playbook_recursive = os.path.join(data_dir, "import_playbook_recursive.yaml")
 
 base_image = "docker.io/library/python:3-alpine"
 


### PR DESCRIPTION
## Basics
Ignores adjusting hosts for import_playbooks statements, as those should not have a host entry. Instead we have to read the imported playbook and correct the possible hosts entries there (this goes on recursively by need, so can support a very big import_playbook-depth). The hosts-corrected imported playbook path/name will need to be used in place of the old one in the playbook that imports it. I decided on a uuid based filename for the temp files, because of the low likelihood of "name-crashes". Currently the temp-file was named p.yaml, and if we have several ones that would off course not work. This PR implements those fixes.

tl;dr: fixes #109 


## About the testing
I initially planned to do everything in tests_core.py, but after some thinking decided to create e2e'ish test in tests_api.py instead. This is because the tests in core would have needed either a lot of setup (duplication of api.py-code maybe), or mocking (in which I think it wouldn't be as useful). Hopefully this is not an issue, as I think the tests I made still verifies the functionality in an ok way. 

The tests tests the example from #109, as well as a recursive one (import_playbook inside an imported playbook). The last one might be overkills. I have also tested manually, and it seems to work as expected in the tests I've done so far 🙂 