### PR TITLE
Fix all tests

### DIFF
--- a/ansible_bender/api.py
+++ b/ansible_bender/api.py
@@ -126,6 +126,11 @@ class Application:
             # commit the final image and apply all metadata
             b.final_layer_id = builder.commit(build.target_image, final_image=True)
 
+            if b.squash:
+                logger.debug("Squashing metadata into a single layer")
+                # reset layers if squashing
+                b.wipe_layers()
+                self.record_progress(b, None, b.final_layer_id)
             if not b.is_layering_on():
                 self.record_progress(b, None, b.final_layer_id)
             else:

--- a/ansible_bender/conf.py
+++ b/ansible_bender/conf.py
@@ -255,6 +255,11 @@ class Build:
         self.layers.append(layer)
         self.layer_index[layer_id] = layer
 
+    def wipe_layers(self):
+        """ remove all layers from the DB: used by squash """
+        self.layers = []
+        self.layer_index = {}
+
     def get_top_layer_id(self):
         """
         return id of the top layer, or None

--- a/ansible_bender/core.py
+++ b/ansible_bender/core.py
@@ -55,12 +55,16 @@ from ansible_bender.utils import run_cmd, ap_command_exists, random_str, gracefu
     is_ansibles_python_2
 
 logger = logging.getLogger(__name__)
+# callback_whitelist got renamed to callbacks_enabled in ansible
+# drop callback_whitelist once 2.15 is released
+# https://docs.ansible.com/ansible/latest/reference_appendices/config.html#callbacks-enabled
 A_CFG_TEMPLATE = """\
 [defaults]
 # when user is changed, ansible might not be able to write to /.ansible
 remote_tmp = /tmp
 callback_plugins={0}
 callback_whitelist=snapshoter\n
+callbacks_enabled=snapshoter\n
 """
 
 

--- a/ansible_bender/db.py
+++ b/ansible_bender/db.py
@@ -175,7 +175,6 @@ class Database:
         else:
             raise Exception(f'Database seems to be corrupted. Build {next_build_id} already exists.')
 
-
     def record_build(self, build_i, build_id=None, build_state=None, set_finish_time=False):
         """
         record build into database

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def ab(args, tmpdir_path, return_output=False, ignore_result=False, env=None):
 
     :return:
     """
-    # put --debug in there for debugging
+    # put --debug in args for debugging
     cmd = ["python3", "-m", "ansible_bender.cli", "--database-dir", tmpdir_path] + args
     logger.debug("cmd = %s", cmd)
     if ignore_result:

--- a/tests/functional/test_buildah.py
+++ b/tests/functional/test_buildah.py
@@ -296,3 +296,16 @@ def test_two_build_vols(tmpdir, target_image):
 
     assert vol_spec1 in build_volumes
     assert vol_spec2 in build_volumes
+
+
+def test_squash(target_image, tmpdir):
+    cmd = ["build", "--squash", basic_playbook_path, base_image, target_image]
+
+    ab(cmd, str(tmpdir))
+
+    p_inspect_data = json.loads(subprocess.check_output(["podman", "inspect", "-t", "image", target_image]))[0]
+    assert len(p_inspect_data["RootFS"]["Layers"]) == 1
+
+    cmd = ["inspect", "--json"]
+    ab_inspect_data = json.loads(ab(cmd, str(tmpdir), return_output=True))
+    assert len(ab_inspect_data["layers"]) == 1

--- a/tests/functional/test_buildah.py
+++ b/tests/functional/test_buildah.py
@@ -149,7 +149,7 @@ def test_build_failure(tmpdir):
     with pytest.raises(subprocess.CalledProcessError):
         ab(cmd, str(tmpdir))
     out = ab(["get-logs"], str(tmpdir), return_output=True).lstrip()
-    assert out.startswith("PLAY [registry")
+    assert "PLAY [registry" in out
 
     # regex string for target image
     image_name_regex = "%s+[-]+[0-9]+[-]+[0-9]+-failed" %(target_image)

--- a/tests/functional/test_buildah.py
+++ b/tests/functional/test_buildah.py
@@ -126,7 +126,7 @@ def test_build_basic_image_with_all_params(tmpdir, target_image):
            basic_playbook_path, base_image, target_image]
     ab(cmd, str(tmpdir))
     out = inspect_resource("image", target_image)
-    assert out['ImageAnnotations'] == {'bohemian': 'rhapsody'}
+    assert out['ImageAnnotations']['bohemian'] == 'rhapsody'
     co = out["Docker"]["config"]
     assert co["WorkingDir"] == workdir_path
     assert co["Labels"]["A"] == "B"

--- a/tests/functional/test_buildah.py
+++ b/tests/functional/test_buildah.py
@@ -87,7 +87,7 @@ def test_build_basic_image_with_build_volumes(tmpdir, target_image):
     with open(os.path.join(real_tmp, "file.txt"), "w") as fd:
         fd.write("Hello, hello!")
     container_mount = "/asdqwe"
-    vol_spec = "%s:%s" % (real_tmp, container_mount)
+    vol_spec = "%s:%s:Z" % (real_tmp, container_mount)
     cmd = ["build", "--build-volumes", vol_spec, "--",
            basic_playbook_path_w_bv, base_image, target_image]
     ab(cmd, str(tmpdir))

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -67,7 +67,7 @@ def test_get_logs(target_image, tmpdir):
     cmd = ["build", basic_playbook_path, base_image, target_image]
     ab(cmd, str(tmpdir))
     out = ab(["get-logs"], str(tmpdir), return_output=True).lstrip()
-    assert out.startswith("PLAY [registry")
+    assert "PLAY [registry" in out
     assert "TASK [Gathering Facts]" in out
     assert "failed=0" in out
     assert "TASK [print local env vars]" in out

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -26,7 +26,7 @@ def test_build_db_metadata(application, build):
     assert build.build_start_time is not None
     assert build.log_lines is not None
     logs = "\n".join([l for l in build.log_lines if l])
-    assert logs.startswith("PLAY [registry")
+    assert "PLAY [registry" in logs
     assert "TASK [Gathering Facts]" in logs
     assert "failed=0" in logs
 


### PR DESCRIPTION
TODO:
* [x] fix all test failures:
  * [x] fix `test_build_basic_image_with_all_params` test
  * [x] tests/integration/test_api.py::test_build_db_metadata
  * [x] tests/functional/test_cli.py::test_get_logs
  * [x] tests/functional/test_buildah.py::test_build_failure
  * [x] tests/functional/test_buildah.py::test_build_basic_image_with_build_volumes

also has:
```
callback_whitelist is deprecated

so let's set both to be backwards compatible and drop callback_whitelist
once 2.15 is out
```