### PR TITLE
Remove Docker hub dependency in tests

### DIFF
--- a/tests/data/b_p_w_vars.yaml
+++ b/tests/data/b_p_w_vars.yaml
@@ -2,7 +2,7 @@
   vars:
     ansible_bender:
       verbose_layer_names: true
-      base_image: "docker.io/library/python:3-alpine"
+      base_image: "quay.io/biocontainers/python:3"
 
       working_container:
         volumes:

--- a/tests/data/p_w_vars_files.yaml
+++ b/tests/data/p_w_vars_files.yaml
@@ -1,7 +1,7 @@
 - hosts: all
   vars:
     ansible_bender:
-      base_image: "docker.io/library/python:3-alpine"
+      base_image: "quay.io/biocontainers/python:3"
       target_image:
         name: with-vars-files
         labels:

--- a/tests/data/pb_wrong_type.yaml
+++ b/tests/data/pb_wrong_type.yaml
@@ -1,7 +1,7 @@
 - hosts: all
   vars:
     ansible_bender:
-      base_image: "docker.io/library/python:3-alpine"
+      base_image: "quay.io/biocontainers/python:3"
       target_image: my-image-name
   tasks:
   - copy:

--- a/tests/data/playbook_with_unknown_keys.yaml
+++ b/tests/data/playbook_with_unknown_keys.yaml
@@ -6,7 +6,7 @@
         name: unknown_key
 
       verbose_layer_names: true
-      base_image: "docker.io/library/python:3-alpine"
+      base_image: "quay.io/biocontainers/python:3"
 
       working_container:
         volumes:

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -29,7 +29,7 @@ def test_inspect_cmd(tmpdir, target_image):
     ab(cmd, str(tmpdir))
     out = ab(["inspect"], str(tmpdir), return_output=True)
 
-    assert "base_image: docker.io/library/python:3-alpine" in out
+    assert "base_image: quay.io/biocontainers/python:3" in out
     assert "build_container: " in out
     assert "build_finished_time: " in out
     assert "build_start_time: " in out

--- a/tests/functional/test_conf.py
+++ b/tests/functional/test_conf.py
@@ -24,7 +24,7 @@ def test_basic(tmpdir):
         cmd = ["inspect", "--json"]
         ab_inspect_data = json.loads(ab(cmd, str(tmpdir), return_output=True))
 
-        assert ab_inspect_data["base_image"] == "docker.io/library/python:3-alpine"
+        assert ab_inspect_data["base_image"] == "quay.io/biocontainers/python:3"
         assert ab_inspect_data["build_id"] == "1"
         assert ab_inspect_data['build_volumes'] == [f'{data_dir}:/src:Z']
         assert ab_inspect_data['builder_name'] == "buildah"
@@ -65,7 +65,7 @@ def test_with_vars_files(tmpdir):
         cmd = ["inspect", "--json"]
         ab_inspect_data = json.loads(ab(cmd, str(tmpdir), return_output=True))
 
-        assert ab_inspect_data["base_image"] == "docker.io/library/python:3-alpine"
+        assert ab_inspect_data["base_image"] == "quay.io/biocontainers/python:3"
         assert ab_inspect_data["build_id"] == "1"
         assert ab_inspect_data['builder_name'] == "buildah"
         assert len(ab_inspect_data['layers']) == 3

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -303,7 +303,7 @@ def test_pb_with_role(build, application):
 
 @pytest.mark.parametrize("image_name,interpreter", [
     ("registry.fedoraproject.org/fedora:35", "/usr/bin/python3"),
-    ("docker.io/library/python:2.7-alpine", "/usr/local/bin/python2"),
+    ("quay.io/biocontainers/python:2.7", "/usr/local/bin/python2"),
     ("registry.access.redhat.com/ubi8/ubi:8.2", "/usr/libexec/platform-python")
 ])
 def test_cache_python_interpreter(application, build, image_name, interpreter):

--- a/tests/integration/test_buildah.py
+++ b/tests/integration/test_buildah.py
@@ -28,7 +28,7 @@ OS/Arch:         linux/amd64
     ("registry.fedoraproject.org/fedora:33", True),
     ("registry.access.redhat.com/ubi8/python-38", True),
     (base_image, True),
-    ("docker.io/library/busybox", False),
+    ("quay.io/quay/busybox", False),
     ])
 def test_find_py_intrprtr_in_fedora_image(image_name, found):
     build = Build()

--- a/tests/integration/test_conf.py
+++ b/tests/integration/test_conf.py
@@ -17,7 +17,7 @@ from tests.spellbook import b_p_w_vars_path, basic_playbook_path, full_conf_pb_p
 def test_expand_pb_vars():
     p = PbVarsParser(b_p_w_vars_path)
     data = p.expand_pb_vars()
-    assert data["base_image"] == "docker.io/library/python:3-alpine"
+    assert data["base_image"] == "quay.io/biocontainers/python:3"
     assert data["verbose_layer_names"]
     playbook_dir = os.path.dirname(b_p_w_vars_path)
     assert data["working_container"]["volumes"] == [f"{playbook_dir}:/src:Z"]

--- a/tests/spellbook.py
+++ b/tests/spellbook.py
@@ -26,7 +26,7 @@ playbook_wrong_type = os.path.join(data_dir, "pb_wrong_type.yaml")
 import_playbook_basic = os.path.join(data_dir, "import_playbook_basic.yaml")
 import_playbook_recursive = os.path.join(data_dir, "import_playbook_recursive.yaml")
 
-base_image = "docker.io/library/python:3-alpine"
+base_image = "quay.io/biocontainers/python:3"
 
 
 C7_AP_VER_OUT = """\


### PR DESCRIPTION
See #244. Docker hub has a pull quota for images, about 100 in 6 hours. This can cause tests to fail. Experienced it locally when I got acquainted with the source code (modifying code, running tests, deleting images, rinse and repeat 😛  ). Unsure if the tests run on the same machines with the same IPs in CI, but it could in theory happen there as well. 

Believe this, combined with the PR @TomasTomecek is currently doing, #269, will make contributions more pleasant 🙂  Green pipeline and zero random Docker hub related issues are a good thing after all.


Criteria used to select replacement images (all from Quay.io):
- Not too big in size! Should be quick'ish to download. 
- Reputable organization or project creating the images. Unsure if pushing the same tag twice is allowed at Quay, but untrusty organizations could in theory do such a thing and add weird stuff.
- Not too many security warnings on Quay.io
- As little changes to existing tests as possible. 
