### PR TITLE
Pass extra args to podman run and ansible run

### DIFF
--- a/ansible_bender/cli.py
+++ b/ansible_bender/cli.py
@@ -179,6 +179,14 @@ class CLI:
             help="arguments passed to buildah from command (be careful!)"
         )
         self.build_parser.add_argument(
+            "--extra-buildah-run-args",
+            help="arguments passed to buildah run command (be careful!)"
+        )
+        self.build_parser.add_argument(
+            "--extra-podman-run-args",
+            help="arguments passed to podman run command (be careful!)"
+        )
+        self.build_parser.add_argument(
             "--extra-ansible-args",
             help="arguments passed to ansible-playbook command (be careful!)"
         )
@@ -330,6 +338,10 @@ class CLI:
             build.squash = self.args.squash
         if self.args.extra_buildah_from_args:
             build.buildah_from_extra_args = self.args.extra_buildah_from_args
+        if self.args.extra_buildah_run_args:
+            build.buildah_run_extra_args = self.args.extra_buildah_run_args
+        if self.args.extra_podman_run_args:
+            build.podman_run_extra_args = self.args.extra_podman_run_args
         if self.args.extra_ansible_args:
             build.ansible_extra_args = self.args.extra_ansible_args
         if self.args.python_interpreter:

--- a/ansible_bender/conf.py
+++ b/ansible_bender/conf.py
@@ -147,6 +147,8 @@ class Build:
         self.verbose = False
         self.pulled = False  # was the base image pulled?
         self.buildah_from_extra_args = None
+        self.buildah_run_extra_args = None
+        self.podman_run_extra_args = None
         self.ansible_extra_args = None
         self.python_interpreter = None
         self.verbose_layer_names = False
@@ -180,6 +182,8 @@ class Build:
             "verbose": self.verbose,
             "pulled": self.pulled,
             "buildah_from_extra_args": self.buildah_from_extra_args,
+            "buildah_run_extra_args": self.buildah_run_extra_args,
+            "podman_run_extra_args": self.podman_run_extra_args,
             "ansible_extra_args": self.ansible_extra_args,
             "python_interpreter": self.python_interpreter,
             "verbose_layer_names": self.verbose_layer_names,
@@ -197,6 +201,8 @@ class Build:
         self.layering = graceful_get(data, "layering", default=self.layering)
         self.squash = graceful_get(data, "squash", default=self.squash)
         self.buildah_from_extra_args = graceful_get(data, "buildah_from_extra_args")
+        self.buildah_run_extra_args = graceful_get(data, "buildah_run_extra_args")
+        self.podman_run_extra_args = graceful_get(data, "podman_run_extra_args")
         self.ansible_extra_args = graceful_get(data, "ansible_extra_args")
         self.verbose_layer_names = graceful_get(data, "verbose_layer_names")
         # we should probably get this from the official Ansible variable
@@ -238,6 +244,8 @@ class Build:
         b.pulled = j["pulled"]
         b.buildah_from_extra_args = j.get("buildah_from_extra_args", None)
         b.ansible_extra_args = j.get("ansible_extra_args", None)
+        b.buildah_run_extra_args = j.get("buildah_run_extra_args", None)
+        b.podman_run_extra_args = j.get("podman_run_extra_args", None)
         b.python_interpreter = j.get("python_interpreter", None)
         b.verbose_layer_names = graceful_get(j, "verbose_layer_names", default=False)
         return b

--- a/ansible_bender/schema.py
+++ b/ansible_bender/schema.py
@@ -417,5 +417,13 @@ PLAYBOOK_SCHEMA = {
             "type": "string",
             "title": "provide extra arguments for `buildah from` command"
         },
+        "buildah_run_extra_args": {
+            "type": "string",
+            "title": "provide extra arguments for `buildah run` command",
+        },
+        "podman_run_extra_args": {
+            "type": "string",
+            "title": "provide extra arguments for `podman run` command",
+        },
     },
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,8 @@ only from the first play. All the plays will end up in a single container image.
 |---------------------------|--------|---------------------------------------------------------
 | `base_image`              | string | name of the container image to use as a base
 | `buildah_from_extra_args` | string | extra CLI arguments to pass to buildah from command
+| `buildah_run_extra_args`  | string | extra CLI arguments to pass to buildah run command
+| `podman_run_extra_args`   | string | extra CLI arguments to pass to podman run command
 | `ansible_extra_args`      | string | extra CLI arguments to pass to ansible-playbook command
 | `working_container`       | dict   | settings for the container where the build occurs
 | `target_image`            | dict   | metadata of the final image which we built

--- a/tests/data/full_conf_pb.yaml
+++ b/tests/data/full_conf_pb.yaml
@@ -7,6 +7,8 @@
       cache_tasks: false
       ansible_extra_args: "--some --args"
       buildah_from_extra_args: "--more --args"
+      buildah_run_extra_args: "--hostname=foo"
+      podman_run_extra_args: "--network=host -e=FOO=BAR"
 
       working_container:
         volumes:

--- a/tests/functional/test_buildah.py
+++ b/tests/functional/test_buildah.py
@@ -55,7 +55,7 @@ def test_build_basic_image_with_env_vars(tmpdir, target_image):
     out = inspect_resource("image", target_image)
     assert a_b in out["OCIv1"]["config"]["Env"]
     assert x_y in out["OCIv1"]["config"]["Env"]
-    e = podman_run_cmd(target_image, ["env"], return_output=True)
+    e = podman_run_cmd(target_image, ["env"], [], return_output=True)
     assert a_b in e
     assert x_y in e
 
@@ -269,7 +269,7 @@ def test_tback_in_callback(tmpdir):
             assert re.match(image_name_regex, ab_inspect_data["target_image"])
             assert len(ab_inspect_data["layers"]) == 2
             with pytest.raises(subprocess.CalledProcessError) as ex:
-                podman_run_cmd(ab_inspect_data["target_image"], ["ls", "/fun"], return_output=True)
+                podman_run_cmd(ab_inspect_data["target_image"], ["ls", "/fun"], [], return_output=True)
             assert "No such file or directory" in ex.value.output
         finally:
             subprocess.call(["buildah", "rmi", ab_inspect_data["target_image"]])

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -279,7 +279,7 @@ def test_multiplay(build, application):
     application.build(build)
     try:
         build = application.db.get_build(build.build_id)
-        podman_run_cmd(im, ["ls", "/queen"])  # the file has to be in there
+        podman_run_cmd(im, ["ls", "/queen"], [])  # the file has to be in there
         assert len(build.layers) == 3
     finally:
         run_cmd(["buildah", "rmi", im], ignore_status=True, print_output=True)
@@ -293,7 +293,7 @@ def test_pb_with_role(build, application):
     application.build(build)
     try:
         build = application.db.get_build(build.build_id)
-        podman_run_cmd(im, ["ls", "/officer"])  # the file has to be in there
+        podman_run_cmd(im, ["ls", "/officer"], [])  # the file has to be in there
         # base image + 2 from roles: [] + 2 from import_role
         # + 3 from include_role (include_role is a task)
         assert len(build.layers) == 8

--- a/tests/integration/test_conf.py
+++ b/tests/integration/test_conf.py
@@ -60,6 +60,8 @@ def test_set_all_params():
     assert b.layering
     assert not b.cache_tasks
     assert b.ansible_extra_args == "--some --args"
+    assert b.buildah_run_extra_args == "--hostname=foo"
+    assert b.podman_run_extra_args == "--network=host -e=FOO=BAR"
     assert b.build_volumes == ["/c:/d"]
     assert b.build_entrypoint == "ls"
     assert b.target_image == "funky-mona-lisa"

--- a/tests/unit/test_buildah.py
+++ b/tests/unit/test_buildah.py
@@ -1,10 +1,11 @@
 import json
 
 from ansible_bender.builders import buildah_builder
-from ansible_bender.builders.buildah_builder import get_buildah_image_id
+from ansible_bender.builders.buildah_builder import BuildahBuilder, get_buildah_image_id
+from ansible_bender.conf import Build
 from flexmock import flexmock
 
-from tests.spellbook import buildah_inspect_data_path
+from tests.spellbook import base_image, buildah_inspect_data_path
 
 
 def mock_inspect():
@@ -17,3 +18,11 @@ def test_buildah_id():
     mock_inspect()
     assert get_buildah_image_id("this-is-mocked") == "6aed6d59a707a7040ad25063eafd3a2165961a2c9f4d1d06ed0a73bdf2a89322"
 
+def test_extra():
+    build = Build()
+    build.base_image = base_image
+    build.podman_run_extra_args = "--network=host -e=FOO=BAR"
+    build.buildah_run_extra_args = "--hostname=foo"
+    b = BuildahBuilder(build, debug=True)
+    assert b.podman_run_args == ["--network=host", "-e=FOO=BAR"]
+    assert b.buildah_run_args == ["--hostname=foo"]


### PR DESCRIPTION
This PR adds two new options so that users can pass additional arguments to `buildah run` and `podman run` commands.

cc @rafmagns-skepa-dreag 