### PR TITLE
remove: selinux checks

### DIFF
--- a/ansible_bender/core.py
+++ b/ansible_bender/core.py
@@ -265,38 +265,12 @@ class PbVarsParser:
         self.metadata = ImageMetadata()
         self.build.metadata = self.metadata
 
-    def _check_selinux_iz_gud(self):
-        """
-        This is a workaround for a weird behavior of ansible: if selinux is
-        in the enforcing mode and python3-libselinux is not installed, ansible freezes
-
-        https://bugzilla.redhat.com/show_bug.cgi?id=1696706
-        :return:
-        """
-        try:
-            enforcing_status = Path("/sys/fs/selinux/enforce").read_text()
-        except FileNotFoundError:
-            logger.debug("this system is not using selinux, /sys/fs/selinux/enforce is not present")
-            return
-        logger.debug(f"selinux enforce status = {enforcing_status}")
-        # it can be enforcing or not, selinux python module needs to be present
-        try:
-            importlib.import_module("selinux")
-        except ModuleNotFoundError:
-            raise RuntimeError(
-                "\nThis system is using selinux(8) and selinux python module is not installed. "
-                "There is a known issue in ansible that it freezes in this setup:\n"
-                "  https://bugzilla.redhat.com/show_bug.cgi?id=1696706\n"
-                "Please install libselinux python bindings (on Fedora the package name is python3-libselinux)."
-            )
-
     def expand_pb_vars(self):
         """
         populate vars from a playbook, defined in vars section
 
         :return: dict with the content of ansible_bender var
         """
-        self._check_selinux_iz_gud()
         with open(self.playbook_path) as fd:
             plays = yaml.safe_load(fd)
 

--- a/tests/unit/test_ansibla.py
+++ b/tests/unit/test_ansibla.py
@@ -54,17 +54,6 @@ def mock_import_module(raise_exc=False):
         False
     ),
 ))
-def test_ansible_selinux_workaround(mock_r_t, mock_i_m, should_raise):
-    mock_r_t()
-    mock_i_m()
-    p = PbVarsParser("")
-    if should_raise:
-        with pytest.raises(RuntimeError) as ex:
-            p._check_selinux_iz_gud()
-        assert "libselinux" in str(ex.value)
-    else:
-        p._check_selinux_iz_gud()
-
 
 @pytest.mark.parametrize("di, error_message", (
     (


### PR DESCRIPTION
Closes #275 

This removes the selinux related checks built into ansible-bender. The selinux checks were done to workaround [this bug report](https://bugzilla.redhat.com/show_bug.cgi?id=1696706), but I believe the bug report is no longer applicable.