### PR TITLE
packit: fix RPM builds & CI

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -20,3 +20,6 @@ jobs:
   trigger: release
   metadata:
     dist-git-branch: master
+srpm_build_deps:
+  - python3-pip # "python3 setup.py --version" needs it
+  - python3-setuptools_scm


### PR DESCRIPTION
we now need to define all dependencies needed to produce RPMs