### PR TITLE
Remove pkg_resources usage

### DIFF
--- a/ansible_bender/__init__.py
+++ b/ansible_bender/__init__.py
@@ -6,9 +6,13 @@ ab (ansible builder) is a tool which enables you to build container images using
 $ ab build ./playbook.yaml fedora:28 my-custom-image
 
 """
-from pkg_resources import get_distribution, DistributionNotFound
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+    from importlib_metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version(__name__)
+except PackageNotFoundError:
     # package is not installed
-    pass
+    __version__ = None

--- a/ansible_bender/cli.py
+++ b/ansible_bender/cli.py
@@ -6,10 +6,10 @@ import argparse
 import json
 import sys
 import subprocess
-import pkg_resources
 import yaml
 from tabulate import tabulate
 
+from ansible_bender import __version__
 from ansible_bender.api import Application
 from ansible_bender.constants import ANNOTATIONS_KEY, PLAYBOOK_TEMPLATE
 from ansible_bender.core import AnsibleVarsParser
@@ -421,9 +421,9 @@ class CLI:
         subcommand = getattr(self.args, "subcommand", "nope")
         try:
             if self.args.version:
-                try:
-                    print(pkg_resources.get_distribution("ansible-bender").version)
-                except pkg_resources.DistributionNotFound:
+                if __version__ is not None:
+                    print(__version__)
+                else:
                     print("Ansible-bender is not installed, therefore we can't print the version.")
                     print("Please run `python3 setup.py --version` instead.")
                     return 18

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
     "tabulate",
     "jsonschema",
     "setuptools",
+    # https://peps.python.org/pep-0631/
+    "importlib_metadata; python_version < '3.8'",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
pkg_resources is deprecated [1] and expensive to import. Use the newer,
leaner importlib.metadata package instead.

[1] https://github.com/pypa/setuptools/commit/a1aeda391a0c462ea53627bcdf50dd4c0daadaed
