### PR TITLE
add GHA: build and publish releases to PyPI

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -1,0 +1,31 @@
+# Upload a Python package when a release is created
+# https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows
+
+name: Publish Python 🐍 distributions 📦 to PyPI
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  # TODO: rewrite this as 2 separate jobs: https://github.com/cherrypy/cheroot/blob/56d7b49/.github/workflows/ci-cd.yml#L989
+  # Thanks @webknjaz
+  pypi-build-and-publish:
+    name: Build and upload release to PyPI
+    runs-on: ubuntu-latest
+    environment: pypi-publish
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - name: Build a source tarball and a binary wheel
+        # https://pypa-build.readthedocs.io
+        run: |
+          python -m pip install build
+          python -m build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true


### PR DESCRIPTION
...using the Trusted Publisher Management:

- https://docs.pypi.org/trusted-publishers/
- https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
- https://github.com/pypa/gh-action-pypi-publish#trusted-publishing

Fixes: https://github.com/ansible-community/ansible-bender/issues/291